### PR TITLE
Add TeamoRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of awesome solutions and research in AI model routing. Other awes
 - [RoRF](https://www.notdiamond.ai/blog/rorf): SOTA open-source pairwise router based on a random forest architecture.
 - [RouteLLM](https://github.com/lm-sys/RouteLLM/tree/main)*: RouteLLM is a framework for serving and evaluating LLM routers.
 - [Semantic Router](https://github.com/aurelio-labs/semantic-router)*: Route inputs to different models using semantic embeddings.
+- [TeamoRouter](https://router.teamolab.com): Native LLM routing gateway for OpenClaw. One API key for Claude, GPT-4o, Gemini, DeepSeek, Kimi, MiniMax with smart routing modes (quality-first, balanced, cheapest) and automatic provider failover.
 - [Unify](https://unify.ai/): Improve quality, cost and speed by routing to the perfect model and provider for each individual prompt.
 
 ## AI model routing papers


### PR DESCRIPTION
TeamoRouter is a native LLM routing gateway built for the OpenClaw ecosystem.

- One API key for Claude, GPT-4o, Gemini, DeepSeek, Kimi, MiniMax
- Smart routing modes: teamo-best (quality), teamo-balanced (auto-select), teamo-eco (cheapest)
- Automatic provider failover (circuit breaker)
- 2-second install via OpenClaw skill
- Up to 50% off official API prices

Website: https://router.teamolab.com