### PR TITLE
Add Herma AI to intelligent routing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A curated list of awesome solutions and research in AI model routing. Other awes
 
 *Open-source tools and software solutions for AI model routing (ordered alphabetically). `*` indicates that an entry is open source.*
 
+- [Herma AI](https://hermaai.com/): Intelligent LLM router that automatically selects the optimal model per request for cost savings with quality retention.
 - [Martian](https://www.withmartian.com/): Dynamically routes requests to the best LLM in real-time.
 - [Neutrino AI](https://www.neutrinoapp.com/): Intelligently route queries to the best-suited LLM for the prompt.
 - [Not Diamond](https://www.notdiamond.ai/): An AI model router that automatically determines which LLM is best-suited to respond to any query.


### PR DESCRIPTION
Adds [Herma AI](https://hermaai.com/) to the intelligent AI model routing section.

Herma AI is an intelligent LLM router that automatically selects the optimal model per request, optimizing for cost savings while maintaining quality retention. Placed alphabetically before Martian.