### PR TITLE
Add FerryAPI to model routing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A curated list of awesome solutions and research in AI model routing. Other awes
 
 *Open-source tools and software solutions for AI model routing (ordered alphabetically). `*` indicates that an entry is open source.*
 
+- [FerryAPI](https://www.ferryapi.io/): OpenAI-compatible AI API gateway for routing AI SaaS and developer-tool traffic through one Base URL, with usage visibility, quota controls, and prepaid cost management.
 - [Martian](https://www.withmartian.com/): Dynamically routes requests to the best LLM in real-time.
 - [Neutrino AI](https://www.neutrinoapp.com/): Intelligently route queries to the best-suited LLM for the prompt.
 - [Not Diamond](https://www.notdiamond.ai/): An AI model router that automatically determines which LLM is best-suited to respond to any query.


### PR DESCRIPTION
Adds FerryAPI to the intelligent AI model routing tools section.

FerryAPI provides an OpenAI-compatible gateway layer for routing AI SaaS and developer-tool traffic through one Base URL, with usage visibility, quota controls, and prepaid cost management.

Disclosure: I work on FerryAPI and am submitting this as a relevant addition for review.