### PR TITLE
Add TierDecay (open-source tier router for coding CLIs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of awesome solutions and research in AI model routing. Other awes
 - [RoRF](https://www.notdiamond.ai/blog/rorf): SOTA open-source pairwise router based on a random forest architecture.
 - [RouteLLM](https://github.com/lm-sys/RouteLLM/tree/main)*: RouteLLM is a framework for serving and evaluating LLM routers.
 - [Semantic Router](https://github.com/aurelio-labs/semantic-router)*: Route inputs to different models using semantic embeddings.
+- [TierDecay](https://github.com/alebgl77/tierdecay)*: Self-distilling tier router for AI coding CLIs — solves each task class once at an expensive model tier, distills it into a low-tier playbook entry, and decays the class's default tier down using a ledger of predicted-vs-executed tiers.
 - [Unify](https://unify.ai/): Improve quality, cost and speed by routing to the perfect model and provider for each individual prompt.
 
 ## AI model routing papers


### PR DESCRIPTION
Adds **TierDecay** to *Intelligent AI model routing* (open-source, marked with `*`, placed alphabetically between Semantic Router and Unify).

- **Repo:** https://github.com/alebgl77/tierdecay (MIT)
- **What it routes:** it's a self-distilling *tier* router for AI coding CLIs. A cold-start rubric scores each task; a ledger of predicted-vs-executed tiers becomes the empirical posterior that overrides the rubric; when an expensive tier solves a recurring problem class it distills the decision into a ≤15-line playbook entry, and the next occurrences are probed one tier cheaper until the class's default tier drops for good (T3→T2→T1).
- **Why it fits:** same category as RouteLLM / Semantic Router — routing queries across model tiers to trade cost for quality — but specialized for terminal coding agents (Claude Code, Codex/AGENTS.md, Cursor, Gemini CLI, Aider, Cline, Goose, Windsurf), with the routing decision *learned per repo* rather than fixed.

Single line, open-source `*` marker, matches the existing entry format.