### PR TITLE
Add OpenRoutiQ to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ A curated list of awesome solutions and research in AI model routing. Other awes
 - [Neutrino AI](https://www.neutrinoapp.com/): Intelligently route queries to the best-suited LLM for the prompt.
 - [Not Diamond](https://www.notdiamond.ai/): An AI model router that automatically determines which LLM is best-suited to respond to any query.
 - [notdiamond-0001](https://huggingface.co/notdiamond/notdiamond-0001)*: Automatically determines whether to send queries to GPT-3.5 or GPT-4.
-- [Pulze AI KNN router](https://github.com/pulzeai-oss/knn-router)*: A minimal server for generating a ranked list of targets, for a query, based on its k-nearest semantic neighbors. Written in Go.
 - [OpenRouter](https://openrouter.ai/models/openrouter/auto): Prompts will be sent to Llama 3 70B Instruct, Claude 3.5 Sonnet (self-moderated) or GPT-4o.
+- [OpenRoutiQ](https://github.com/antat-ai/openroutiq)*: An open-source Python router for explainable, policy-controlled selection across models, providers, deployments, and reasoning levels, with optional outcome learning.
+- [Pulze AI KNN router](https://github.com/pulzeai-oss/knn-router)*: A minimal server for generating a ranked list of targets, for a query, based on its k-nearest semantic neighbors. Written in Go.
 - [Requesty](https://www.requesty.ai/solution/smart-routing?github-awesome-list): Configurable smart routing algorithms to optimize your performance, cost or latency.
 - [RoRF](https://www.notdiamond.ai/blog/rorf): SOTA open-source pairwise router based on a random forest architecture.
 - [RouteLLM](https://github.com/lm-sys/RouteLLM/tree/main)*: RouteLLM is a framework for serving and evaluating LLM routers.


### PR DESCRIPTION
## Summary

- add OpenRoutiQ to the Intelligent AI model routing section
- keep the section in case-insensitive alphabetical order
- use a factual description with no benchmark or superlative claims

## Validation

- confirmed there is no existing OpenRoutiQ entry or open submission
- confirmed the public repository URL returns HTTP 200
- verified alphabetical ordering and ran `git diff --check`

## Disclosure

I maintain OpenRoutiQ through the antat-ai organization.